### PR TITLE
Add aria label of member name to sybmolic element

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2263,13 +2263,14 @@ void HtmlGenerator::endMemberDocList()
   DBG_HTML(m_t << "<!-- endMemberDocList -->\n";)
 }
 
-void HtmlGenerator::startMemberDoc( const QCString &/* clName */, const QCString &/* memName */,
+void HtmlGenerator::startMemberDoc( const QCString &/* clName */, const QCString &memName,
                                     const QCString &anchor, const QCString &title,
                                     int memCount, int memTotal, bool /* showInline */)
 {
   DBG_HTML(m_t << "<!-- startMemberDoc -->\n";)
   m_t << "\n<h2 class=\"memtitle\">"
-      << "<span class=\"permalink\"><a href=\"#" << anchor << "\">&#9670;&#160;</a></span>";
+      << R"(<span class="permalink"><a href="#)" << anchor << R"(" aria-label=")" << memName
+      << R"(">&#9670;&#160;</a></span>)";
   docify(title);
   if (memTotal>1)
   {


### PR DESCRIPTION
Before when creating class members it would create html like

```
<a href="#a21afb5f40b2e2c14009caa1370307767">◆&nbsp;</a>
```

where the diamond is what is shown so screen readers would not play nicely with it. update it to

```
<a href="#adb05a676ad0a3ffec523d891de4cd8a4" aria-label="GeneratePresignedUrl">◆&nbsp;</a>
```

so that it will play nicely with screen readers