### PR TITLE
Remove hover functionality of the search select box

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -76,9 +76,7 @@ static void writeClientSearchBox(TextStream &t,const QCString &relPath)
   t << "        <div id=\"MSearchBox\" class=\"MSearchBoxInactive\">\n";
   t << "        <span class=\"left\">\n";
   t << "          <span id=\"MSearchSelect\" tabindex=\"0\" ";
-  t << "               onmouseover=\"return searchBox.OnSearchSelectShow()\" ";
-  t << "               onclick=\"return searchBox.OnSearchSelectShow()\" ";
-  t << "               onmouseout=\"return searchBox.OnSearchSelectHide()\">&#160;</span>\n";
+  t << "               onclick=\"return searchBox.OnSearchSelectShow()\">&#160;</span>\n";
   t << "               <label for=\"MSearchField\">Search</label>";
   t << "          <input type=\"text\" id=\"MSearchField\" value=\"\" placeholder=\""
     << theTranslator->trSearch() << "\" accesskey=\"S\"\n";
@@ -1439,8 +1437,6 @@ void HtmlGenerator::writeSearchInfoStatic(TextStream &t,const QCString &)
   {
     t << "<!-- window showing the filter options -->\n";
     t << "<div id=\"MSearchSelectWindow\" tabindex=\"0\"\n";
-    t << "     onmouseover=\"return searchBox.OnSearchSelectShow()\"\n";
-    t << "     onmouseout=\"return searchBox.OnSearchSelectHide()\"\n";
     t << "     onkeydown=\"return searchBox.OnSearchSelectKey(event)\">\n";
     t << "</div>\n";
     t << "\n";

--- a/templates/html/htmlbase.tpl
+++ b/templates/html/htmlbase.tpl
@@ -132,10 +132,7 @@ MathJax.Hub.Config({
   {% else %}{# !SERVER_BASED_SEARCH #}
    <div id="MSearchBox" class="MSearchBoxInactive">
     <span class="left">
-      <img id="MSearchSelect" src="{{ page.relPath }}search/mag_sel.svg"
-           onmouseover="return searchBox.OnSearchSelectShow()"
-           onmouseout="return searchBox.OnSearchSelectHide()"
-           alt=""/>
+      <img id="MSearchSelect" src="{{ page.relPath }}search/mag_sel.svg" alt=""/>
       <input type="text" id="MSearchField" value="" placeholder="{{ tr.search }}" accesskey="S"
            onfocus="searchBox.OnSearchFieldFocus(true)"
            onblur="searchBox.OnSearchFieldFocus(false)"

--- a/templates/html/htmltabs.tpl
+++ b/templates/html/htmltabs.tpl
@@ -54,10 +54,7 @@
    <li>
      <div id="MSearchBox" class="MSearchBoxInactive">
      <span class="left">
-       <img id="MSearchSelect" src="{{ page.relPath }}search/mag_sel.svg"
-            onmouseover="return searchBox.OnSearchSelectShow()"
-            onmouseout="return searchBox.OnSearchSelectHide()"
-            alt=""/>
+       <img id="MSearchSelect" src="{{ page.relPath }}search/mag_sel.svg" alt=""/>
        <input type="text" id="MSearchField" value="{{ tr.search }}" accesskey="S"
             onfocus="searchBox.OnSearchFieldFocus(true)"
             onblur="searchBox.OnSearchFieldFocus(false)"

--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -836,7 +836,7 @@ function init_search()
   var input = document.getElementById("MSearchSelect");
   var searchSelectWindow = document.getElementById("MSearchSelectWindow");
 
-  input.addEventListener("keypress", function(event) {
+  input.addEventListener("keydown", function(event) {
     if (event.key === "Enter") {
       event.preventDefault();
       if (searchSelectWindow.style.display == 'block') {
@@ -846,6 +846,8 @@ function init_search()
         searchBox.OnSearchSelectShow();
         searchSelectWindow.focus();
       }
+    } else if (event.key === "Escape") {
+      searchBox.OnSearchSelectHide();
     }
   });
 }


### PR DESCRIPTION
Removes the `onmouseover` functionality from the search select as it was not accessible friendly.