### PR TITLE
Number members with readable names

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1710,7 +1710,17 @@ void HtmlGenerator::writeObjectLink(const QCString &ref,const QCString &f,
     m_t << fn;
   }
   if (!anchor.isEmpty()) m_t << "#" << anchor;
-  m_t << "\">";
+  QCString readableName = [&]() -> QCString {
+      const auto  &find = m_objectLinkSeen.find(name);
+      if (!anchor.isEmpty() && find != m_objectLinkSeen.end()) {
+          auto readableName = name + " " + std::to_string(find->second);
+          find->second += 1;
+          return readableName;
+      }
+      m_objectLinkSeen.emplace(name, 1);
+      return name;
+  }();
+  m_t << "\" aria-label=\"" << readableName << "\">";
   docify(name);
   m_t << "</a>";
 }

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -308,6 +308,7 @@ class HtmlGenerator : public OutputGenerator
     bool                            m_emptySection = false;
     std::unique_ptr<OutputCodeList> m_codeList;
     HtmlCodeGenerator              *m_codeGen = nullptr;
+    std::map<QCString, int>         m_objectLinkSeen;
 };
 
 #endif


### PR DESCRIPTION
Give member function aria labels with distinct names of order number when they share the same name.

i.e. before
```
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a33cd5ac171f31be045caf938453970e2">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a26514f25ed16f33a333e29100175d91d">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#ab168bf3dd7613341c5f7b4f9e523e6ba">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a9d02390fc4a90df4ca0151caaee82d0f">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#acfc9fc014a337ac2e9c2cf3f818c1229">S3Client</a>
```

after
```
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a33cd5ac171f31be045caf938453970e2" aria-label="S3Client 1">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a26514f25ed16f33a333e29100175d91d" aria-label="S3Client 2">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#ab168bf3dd7613341c5f7b4f9e523e6ba" aria-label="S3Client 3">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a9d02390fc4a90df4ca0151caaee82d0f" aria-label="S3Client 4">S3Client</a>
<a class="el" href="class_aws_1_1_s3_1_1_s3_client.html#a23bcdf1f415e01c8961e53137cdcbde0" aria-label="S3Client 5">S3Client</a>
```