### PR TITLE
Add readable name to svg graphs

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -309,9 +309,9 @@ void writeDotImageMapFromFile(TextStream &t,
   if (imgExt=="svg") // vector graphics
   {
     QCString svgName = outDir+"/"+baseName+".svg";
-    DotFilePatcher::writeSVGFigureLink(t,relPath,baseName,svgName);
+    DotFilePatcher::writeSVGFigureLink(t,relPath,baseName,svgName, "Graph");
     DotFilePatcher patcher(svgName);
-    patcher.addSVGConversion("",TRUE,context,TRUE,graphId);
+    patcher.addSVGConversion("",TRUE,context,TRUE,graphId, "Graph");
     patcher.run();
   }
   else // bitmap graphics

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -14,6 +14,7 @@
 */
 
 #include <algorithm>
+#include <queue>
 
 #include "containers.h"
 #include "dotclassgraph.h"
@@ -453,7 +454,8 @@ QCString DotClassGraph::writeGraph(TextStream &out,
   bool generateImageMap,
   int graphId)
 {
-  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId,
+      this->textualRepresentation());
 }
 
 //--------------------------------------------------------------------
@@ -480,4 +482,27 @@ void DotClassGraph::writeDEF(TextStream &t)
   {
     node->writeDEF(t);
   }
+}
+
+QCString DotClassGraph::textualRepresentation() {
+  std::stringstream stream;
+  std::queue<DotNode *> nodes;
+  nodes.emplace(this->m_startNode);
+  while (!nodes.empty()) {
+    DotNode *node = nodes.front();
+    nodes.pop();
+    if (node != nullptr && !node->children().empty()) {
+      stream << node->label();
+      bool firstPass = true;
+      for (const auto &child: node->children()) {
+        if (child != nullptr) {
+          stream << (firstPass ? " Inherits from " : " and ") << child->label();
+          firstPass = false;
+          nodes.push(child);
+        }
+      }
+      stream << ";";
+    }
+  }
+  return stream.str();
 }

--- a/src/dotclassgraph.h
+++ b/src/dotclassgraph.h
@@ -40,6 +40,7 @@ public:
   void writeXML(TextStream &t);
   void writeDocbook(TextStream &t);
   void writeDEF(TextStream &t);
+  QCString textualRepresentation();
 
 protected:
   virtual QCString getBaseName() const;

--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -279,19 +279,21 @@ int DotFilePatcher::addFigure(const QCString &baseName,
 
 int DotFilePatcher::addSVGConversion(const QCString &relPath,bool urlOnly,
                                      const QCString &context,bool zoomable,
-                                     int graphId)
+                                     int graphId,
+                                     const QCString &readableName)
 {
   size_t id = m_maps.size();
-  m_maps.emplace_back("",relPath,urlOnly,context,"",zoomable,graphId);
+  m_maps.emplace_back("",relPath,urlOnly,context,"",zoomable,graphId, readableName);
   return static_cast<int>(id);
 }
 
 int DotFilePatcher::addSVGObject(const QCString &baseName,
                                  const QCString &absImgName,
-                                 const QCString &relPath)
+                                 const QCString &relPath,
+                                 const QCString &readableName)
 {
   size_t id = m_maps.size();
-  m_maps.emplace_back(absImgName,relPath,false,"",baseName);
+  m_maps.emplace_back(absImgName,relPath,false,"",baseName, false, -1, readableName);
   return static_cast<int>(id);
 }
 
@@ -418,7 +420,7 @@ bool DotFilePatcher::run() const
         const Map &map = m_maps.at(mapId);
         //printf("DotFilePatcher::writeSVGFigure: file=%s zoomable=%d\n",
         //  qPrint(m_patchFile),map.zoomable);
-        if (!writeSVGFigureLink(t,map.relPath,map.label,map.mapFile))
+        if (!writeSVGFigureLink(t,map.relPath,map.label,map.mapFile, map.readableName))
         {
           err("Problem extracting size from SVG file %s\n",qPrint(map.mapFile));
         }
@@ -562,8 +564,11 @@ static void writeSVGNotSupported(TextStream &out)
 
 /// Check if a reference to a SVG figure can be written and do so if possible.
 /// Returns FALSE if not possible (for instance because the SVG file is not yet generated).
-bool DotFilePatcher::writeSVGFigureLink(TextStream &out,const QCString &relPath,
-                        const QCString &baseName,const QCString &absImgName)
+bool DotFilePatcher::writeSVGFigureLink(TextStream &out,
+    const QCString &relPath,
+    const QCString &baseName,
+    const QCString &absImgName,
+    const QCString &readableName)
 {
   int width=600,height=600;
   if (!readSVGSize(absImgName,&width,&height))
@@ -578,7 +583,8 @@ bool DotFilePatcher::writeSVGFigureLink(TextStream &out,const QCString &relPath,
     //out << "<object type=\"image/svg+xml\" data=\""
     //out << "<embed type=\"image/svg+xml\" src=\""
     out << "<iframe scrolling=\"no\" frameborder=\"0\" src=\""
-        << relPath << baseName << ".svg\" width=\"100%\" height=\"" << height << "\">";
+        << relPath << baseName << ".svg\" width=\"100%\" height=\"" << height << "\" "
+        << " aria-label=\"" << readableName << "\">";
   }
   else
   {
@@ -587,7 +593,8 @@ bool DotFilePatcher::writeSVGFigureLink(TextStream &out,const QCString &relPath,
     out << "<iframe scrolling=\"no\" frameborder=\"0\" src=\""
         << relPath << baseName << ".svg\" width=\""
         << ((width*96+48)/72) << "\" height=\""
-        << ((height*96+48)/72) << "\">";
+        << ((height*96+48)/72) << "\" "
+        << " aria-label=\"" << readableName << "\">";
   }
   writeSVGNotSupported(out);
   //out << "</object>";

--- a/src/dotfilepatcher.h
+++ b/src/dotfilepatcher.h
@@ -34,10 +34,11 @@ class DotFilePatcher
                   const QCString &figureName,bool heightCheck);
 
     int addSVGConversion(const QCString &relPath,bool urlOnly,
-                         const QCString &context,bool zoomable,int graphId);
+                         const QCString &context,bool zoomable,int graphId,
+                         const QCString &readableName);
 
     int addSVGObject(const QCString &baseName, const QCString &figureName,
-                     const QCString &relPath);
+                     const QCString &relPath, const QCString &readableName);
     bool run() const;
     bool isSVGFile() const;
 
@@ -45,8 +46,11 @@ class DotFilePatcher
                                const QCString &relPath, bool urlOnly=FALSE,
                                const QCString &context=QCString());
 
-    static bool writeSVGFigureLink(TextStream &out,const QCString &relPath,
-                                   const QCString &baseName,const QCString &absImgName);
+    static bool writeSVGFigureLink(TextStream &out,
+        const QCString &relPath,
+        const QCString &baseName,
+        const QCString &absImgName,
+        const QCString &readableName);
 
     static bool writeVecGfxFigure(TextStream& out, const QCString& baseName,
                                   const QCString& figureName);
@@ -55,9 +59,9 @@ class DotFilePatcher
     struct Map
     {
       Map(const QCString &mf,const QCString &rp,bool uo,const QCString &ctx,
-          const QCString &lab,bool zoom=false,int gId=-1) :
+          const QCString &lab,bool zoom=false,int gId=-1, const QCString &rName = "Graph") :
         mapFile(mf), relPath(rp), urlOnly(uo), context(ctx),
-        label(lab), zoomable(zoom), graphId(gId) {}
+        label(lab), zoomable(zoom), graphId(gId), readableName(rName) {}
       QCString mapFile;
       QCString relPath;
       bool     urlOnly;
@@ -65,6 +69,7 @@ class DotFilePatcher
       QCString label;
       bool     zoomable;
       int      graphId;
+      QCString readableName;
     };
     std::vector<Map> m_maps;
     QCString m_patchFile;

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -113,14 +113,15 @@ QCString DotGraph::imgName() const
 std::mutex g_dotIndexListMutex;
 
 QCString DotGraph::writeGraph(
-        TextStream& t,            // output stream for the code file (html, ...)
-        GraphOutputFormat gf,     // bitmap(png/svg) or ps(eps/pdf)
-        EmbeddedOutputFormat ef,  // html, latex, ...
-        const QCString &path,     // output folder
-        const QCString &fileName, // name of the code file (for code patcher)
-        const QCString &relPath,  // output folder relative to code file
-        bool generateImageMap,    // in case of bitmap, shall there be code generated?
-        int graphId)              // number of this graph in the current code, used in svg code
+        TextStream& t,                  // output stream for the code file (html, ...)
+        GraphOutputFormat gf,           // bitmap(png/svg) or ps(eps/pdf)
+        EmbeddedOutputFormat ef,        // html, latex, ...
+        const QCString &path,           // output folder
+        const QCString &fileName,       // name of the code file (for code patcher)
+        const QCString &relPath,        // output folder relative to code file
+        bool generateImageMap,          // in case of bitmap, shall there be code generated?
+        int graphId,                    // number of this graph in the current code, used in svg code
+        const QCString &readableName)   // Readable name of graph
 {
   m_graphFormat = gf;
   m_textFormat = ef;
@@ -143,7 +144,7 @@ QCString DotGraph::writeGraph(
     Doxygen::indexList->addImageFile(imgName());
   }
 
-  generateCode(t);
+  generateCode(t, readableName);
 
   return m_baseName;
 }
@@ -209,7 +210,7 @@ bool DotGraph::prepareDotFile()
   return TRUE;
 }
 
-void DotGraph::generateCode(TextStream &t)
+void DotGraph::generateCode(TextStream &t, const QCString& readableName)
 {
   QCString imgExt = getDotImageExtension();
   if (m_graphFormat==GOF_BITMAP && m_textFormat==EOF_DocBook)
@@ -231,17 +232,17 @@ void DotGraph::generateCode(TextStream &t)
     if (imgExt=="svg") // add link to SVG file without map file
     {
       if (!m_noDivTag) t << "<div class=\"center\">";
-      if (m_regenerate || !DotFilePatcher::writeSVGFigureLink(t,m_relPath,m_baseName,absImgName())) // need to patch the links in the generated SVG file
+      if (m_regenerate || !DotFilePatcher::writeSVGFigureLink(t,m_relPath,m_baseName,absImgName(), readableName)) // need to patch the links in the generated SVG file
       {
         if (m_regenerate)
         {
           DotManager::instance()->
                createFilePatcher(absImgName())->
-               addSVGConversion(m_relPath,FALSE,QCString(),m_zoomable,m_graphId);
+               addSVGConversion(m_relPath,FALSE,QCString(),m_zoomable,m_graphId, readableName);
         }
         int mapId = DotManager::instance()->
                createFilePatcher(m_fileName)->
-               addSVGObject(m_baseName,absImgName(),m_relPath);
+               addSVGObject(m_baseName,absImgName(),m_relPath, readableName);
         t << "<!-- " << "SVG " << mapId << " -->";
       }
       if (!m_noDivTag) t << "</div>\n";

--- a/src/dotgraph.h
+++ b/src/dotgraph.h
@@ -51,7 +51,8 @@ class DotGraph
                         const QCString &fileName,
                         const QCString &relPath,
                         bool writeImageMap=TRUE,
-                        int graphId=-1
+                        int graphId=-1,
+                        const QCString &readableName="Graph"
                        );
 
     static void writeGraphHeader(TextStream& t, const QCString& title = QCString());
@@ -102,7 +103,7 @@ class DotGraph
     DotGraph &operator=(const DotGraph &);
 
     bool prepareDotFile();
-    void generateCode(TextStream &t);
+    void generateCode(TextStream &t, const QCString& readableName);
 
     int m_curNodeNumber = 0;
     int m_curEdgeNumber = 0;

--- a/src/dotlegendgraph.cpp
+++ b/src/dotlegendgraph.cpp
@@ -33,7 +33,7 @@ void DotLegendGraph::writeGraph(const QCString &path)
   {
     DotManager::instance()->
       createFilePatcher(absBaseName()+Config_getString(HTML_FILE_EXTENSION))->
-      addSVGObject("graph_legend", absImgName(),QCString());
+      addSVGObject("graph_legend", absImgName(),QCString(), "Graph");
   }
 }
 


### PR DESCRIPTION
Creates a readable aria label for the svg generated for class inheritence

Before

`<iframe scrolling="no" frameborder="0" src="class_aws_1_1_s3_1_1_s3_client__inherit__graph.svg" width="452" height="200"><p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p></iframe>`

After

`<iframe scrolling="no" frameborder="0" src="class_aws_1_1_s3_1_1_s3_client__inherit__graph.svg" width="452" height="200" aria-label="Aws::S3::S3Client Inherits from Aws::Client::AWSXMLClient and Aws::Client::ClientWithAsyncTemplateMethods< S3Client >;Aws::Client::AWSXMLClient Inherits from Aws::Client::AWSClient;"><p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p></iframe>`