### PR TITLE
show outline one table elements for keyboard users

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -820,10 +820,6 @@ div.directory {
 	padding-top: 3px;
 }
 
-.directory td.entry a {
-        outline:none;
-}
-
 .directory td.entry a img {
         border: none;
 }


### PR DESCRIPTION
When navigating the class list with the keyboard items will now come into focus for keyboard users

![Screenshot 2023-09-21 at 12 26 24 PM](https://github.com/SergeyRyabinin/doxygen/assets/2594044/ade37a9c-c671-40f7-ad6d-b27315b063f3)
