### PR TITLE
fix labels on several elements

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -351,12 +351,17 @@ bool DotFilePatcher::run() const
     int i;
     if (isSVGFile)
     {
+      if (line.find("<svg")!=-1) {
+        line.replace(line.find("<svg"),
+            QCString("<svg").length(),
+            "<svg aria-hidden=\"true\"");
+      }
       if (interactiveSVG)
       {
         if (line.find("<svg")!=-1 && !replacedHeader)
         {
           int count;
-          count = sscanf(line.data(),"<svg width=\"%dpt\" height=\"%dpt\"",&width,&height);
+          count = sscanf(line.data(),R"(<svg aria-hidden="true" width="%dpt" height="%dpt")",&width,&height);
           //printf("width=%d height=%d\n",width,height);
           useNagivation = count==2 && (width>500 || height>450);
           insideHeader = count==2;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -328,12 +328,16 @@ static void startQuickIndexItem(OutputList &ol,const QCString &l,
   ol.writeString("><a ");
   ol.writeString("href=\"");
   ol.writeString(l);
+  if (!label.isEmpty()) {
+    ol.writeString("\" aria-label=\"");
+    ol.writeString(label);
+  }
   ol.writeString("\">");
   if (label.isEmpty()) {
     ol.writeString("<span>");
   } else {
     ol.writeString("<span ");
-    ol.writeString("aria-label: \"");
+    ol.writeString("aria-label=\"");
     ol.writeString(label);
     ol.writeString("\">");
   }


### PR DESCRIPTION
Fixes two issues that were labeled as close, but still flagged.

* Fixes an issue where the iframe was labeled with a readable name, but the svg itself was not. so we are marking the graph as aria-hidden. i.e.

```
<svg xmlns="http://www.w3.org/2000/svg" 
    xmlns:xlink="http://www.w3.org/1999/xlink" 
    aria-hidden="true" 
    width="339pt" 
    height="150pt" 
    viewBox="0.00 0.00 339.00 150.00">
 ...
</svg>
```

* In the namespace letter list, we label the span letters but not the actual links themselves. This also fixes a typo from before.

```
<a href="namespacemembers.html#index_a" aria-label="namespace beginning with a">
  <span aria-label="namespace beginning with a">a</span>
</a>
```